### PR TITLE
perf: split multi-arch builds to avoid 6-hour timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,13 @@ env:
   IMAGE_NAME: phase-alpha/phase-alpha-site
 
 jobs:
-  publish:
-    name: Publish Multi-arch Image
+  build-amd64:
+    name: Build AMD64 Image
     runs-on: ubuntu-latest
-
+    outputs:
+      metadata: ${{ steps.meta.outputs.json }}
+      tags: ${{ steps.meta.outputs.tags }}
+    
     steps:
       - uses: actions/checkout@v5
       
@@ -41,23 +44,94 @@ jobs:
             type=ref,event=pr
             type=raw,value=latest,enable={{is_default_branch}}
             
-      - name: Build and push multi-arch image
+      - name: Build and push AMD64 image
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}-amd64
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: |
-            type=gha,scope=deps-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
-            type=gha,scope=source-${{ github.sha }}
-            type=gha,scope=buildkit-${{ github.ref_name }}
-            type=gha,scope=buildkit-main
+            type=gha,scope=amd64-deps-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
+            type=gha,scope=amd64-${{ github.ref_name }}
+            type=gha,scope=amd64-main
           cache-to: |
-            type=gha,mode=max,scope=deps-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
-            type=gha,mode=max,scope=source-${{ github.sha }}
-            type=gha,mode=max,scope=buildkit-${{ github.ref_name }}
+            type=gha,mode=max,scope=amd64-deps-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
+            type=gha,mode=max,scope=amd64-${{ github.ref_name }}
           build-args: |
             BUILDKIT_INLINE_CACHE=1
           provenance: false
+
+  build-arm64:
+    name: Build ARM64 Image (Raspberry Pi)
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v5
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+            
+      - name: Build and push ARM64 image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=gha,scope=arm64-deps-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
+            type=gha,scope=arm64-${{ github.ref_name }}
+            type=gha,scope=arm64-main
+          cache-to: |
+            type=gha,mode=max,scope=arm64-deps-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
+            type=gha,mode=max,scope=arm64-${{ github.ref_name }}
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+          provenance: false
+
+  create-manifest:
+    name: Create Multi-Arch Manifest
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+            
+      - name: Create and push multi-arch manifest
+        run: |
+          # Get tags from the amd64 build job output
+          TAGS="${{ needs.build-amd64.outputs.tags }}"
+          
+          # Create multi-arch manifest for each tag
+          for tag in $TAGS; do
+            echo "Creating manifest for: $tag"
+            docker buildx imagetools create \
+              --tag "$tag" \
+              "$tag-amd64" \
+              "$tag-arm64"
+          done

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # Stage 1: Build
 FROM rustlang/rust:nightly-bullseye as builder
 
-# Install cargo-leptos and add wasm32 target (cached unless base image changes)
-RUN cargo install --locked cargo-leptos && rustup target add wasm32-unknown-unknown
+# Install cargo-leptos and add wasm32 target in one layer for better caching
+RUN rustup target add wasm32-unknown-unknown && \
+    cargo install --locked cargo-leptos --no-default-features
 
 # Create app directory and set it as the working directory
 RUN mkdir -p /app
@@ -16,9 +17,13 @@ RUN mkdir -p src
 RUN echo "fn main() {}" > src/main.rs
 RUN echo "" > src/lib.rs
 
+# Set environment variables for faster builds
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
 # Build dependencies only (this layer will be cached unless Cargo.toml changes)
-RUN cargo build --release --bin phase-alpha-site --features ssr
-RUN cargo build --release --lib --features hydrate --target wasm32-unknown-unknown
+RUN cargo build --release --bin phase-alpha-site --features ssr -j $(nproc)
+RUN cargo build --release --lib --features hydrate --target wasm32-unknown-unknown -j $(nproc)
 
 # Remove dummy source files
 RUN rm -rf src


### PR DESCRIPTION
- Split single multi-arch job into parallel AMD64 and ARM64 jobs
- Each architecture now has its own 6-hour limit instead of sharing
- Add architecture-specific cache scopes for better isolation
- Optimize Rust compilation with parallel builds and sparse registry
- Install cargo-leptos with --no-default-features for faster setup
- Create multi-arch manifest after both builds complete

This should prevent timeout issues while maintaining ARM64 support for Raspberry Pi.